### PR TITLE
fixing header checks

### DIFF
--- a/all-yara.yar
+++ b/all-yara.yar
@@ -519,7 +519,7 @@ rule HackTool_MSIL_SharPersist_2
         $pdb1 = "\\SharPersist\\"
         $pdb2 = "\\SharPersist.pdb"
     condition:
-        (uint16(0) == 0x5A4D and uint32(uint32(0x3C)) == 0x00004550) and (@pdb2[1] < @pdb1[1] + 50) or (1 of ($a*) and 2 of ($b*))
+        (uint16(0) == 0x5A4D and uint32(uint32(0x3C)) == 0x00004550) and ((@pdb2[1] < @pdb1[1] + 50) or (1 of ($a*) and 2 of ($b*)))
 }
 rule APT_Loader_Win_MATRYOSHKA_1
 {
@@ -809,7 +809,7 @@ rule CredTheft_MSIL_ADPassHunt_2
         $s3 = "[ADA] Searching for accounts with userpassword attribute"
         $s4 = "[GPP] Searching for passwords now"
     condition:
-        (uint16(0) == 0x5A4D and uint32(uint32(0x3C)) == 0x00004550) and (@pdb2[1] < @pdb1[1] + 50) or 2 of ($s*)
+        (uint16(0) == 0x5A4D and uint32(uint32(0x3C)) == 0x00004550) and ((@pdb2[1] < @pdb1[1] + 50) or 2 of ($s*))
 }
 rule APT_Loader_Win64_PGF_4
 {

--- a/rules/ADPASSHUNT/production/yara/CredTheft_MSIL_ADPassHunt_2.yar
+++ b/rules/ADPASSHUNT/production/yara/CredTheft_MSIL_ADPassHunt_2.yar
@@ -12,5 +12,5 @@ rule CredTheft_MSIL_ADPassHunt_2
         $s3 = "[ADA] Searching for accounts with userpassword attribute"
         $s4 = "[GPP] Searching for passwords now"
     condition:
-        (uint16(0) == 0x5A4D and uint32(uint32(0x3C)) == 0x00004550) and (@pdb2[1] < @pdb1[1] + 50) or 2 of ($s*)
+        (uint16(0) == 0x5A4D and uint32(uint32(0x3C)) == 0x00004550) and ((@pdb2[1] < @pdb1[1] + 50) or 2 of ($s*))
 }

--- a/rules/SHARPERSIST/production/yara/HackTool_MSIL_SharPersist_2.yar
+++ b/rules/SHARPERSIST/production/yara/HackTool_MSIL_SharPersist_2.yar
@@ -16,5 +16,5 @@ rule HackTool_MSIL_SharPersist_2
         $pdb1 = "\\SharPersist\\"
         $pdb2 = "\\SharPersist.pdb"
     condition:
-        (uint16(0) == 0x5A4D and uint32(uint32(0x3C)) == 0x00004550) and (@pdb2[1] < @pdb1[1] + 50) or (1 of ($a*) and 2 of ($b*))
+        (uint16(0) == 0x5A4D and uint32(uint32(0x3C)) == 0x00004550) and ((@pdb2[1] < @pdb1[1] + 50) or (1 of ($a*) and 2 of ($b*)))
 }


### PR DESCRIPTION
Modified two rules which have an exe header check in the condition to always require the exe.
The rules were matching on themselves.